### PR TITLE
Fix nginx_extra config per runner

### DIFF
--- a/pypaas/runners/nginxbackend.py
+++ b/pypaas/runners/nginxbackend.py
@@ -54,7 +54,8 @@ class NginxBackend(SimpleProcess, NginxBase):
     def nginx_location(self):
         return nginx_location.format(
             name=self.name,
-            extra_config=self.branch.config.get('nginx_extra_config', '')
+            extra_config=self.branch.config['runners'][self._name]
+                             .get('nginx_extra_config', '')
         )
 
     @property

--- a/pypaas/runners/nginxbackend.py
+++ b/pypaas/runners/nginxbackend.py
@@ -68,8 +68,6 @@ class NginxBackend(SimpleProcess, NginxBase):
                     port=p.port,
                 ) for p in Port.all_for_runner(self)
             ),
-            extra_upstream_config=self.branch.config.get(
-                'nginx_extra_upstream_config',
-                ''
-            )
+            extra_upstream_config=self.branch.config['runners'][self._name]
+                                      .get('nginx_extra_upstream_config', '')
         )

--- a/pypaas/runners/nginxstatic.py
+++ b/pypaas/runners/nginxstatic.py
@@ -31,5 +31,6 @@ class NginxStatic(NginxBase):
                 self.branch.current_checkout.path,
                 subdirectory
             ),
-            extra_config=self.branch.config.get('nginx_extra_config', '')
+            extra_config=self.branch.config['runners'][self._name]
+                             .get('nginx_extra_config', '')
         )


### PR DESCRIPTION
A branch-level `nginx_extra_config` key is not very useful and was never intended. This now uses a runner-level one (like it's documented in the example config).
